### PR TITLE
fix: src/hotspot/share/runtime/cracRecompiler.cpp undefined symbol Method::code()

### DIFF
--- a/src/hotspot/share/runtime/cracRecompiler.cpp
+++ b/src/hotspot/share/runtime/cracRecompiler.cpp
@@ -32,7 +32,7 @@
 #include "nmt/memTag.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/metadata.hpp"
-#include "oops/method.hpp"
+#include "oops/method.inline.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.hpp"


### PR DESCRIPTION
This fixes crac link failure with 25.0.3 release:
```
/usr/bin/x86_64-linux-gnu-g++-15 -Wl,-z,defs -Wl,-z,relro -Wl,-z,now -Wl,--no-as-needed -Wl,--exclude-libs,ALL -Wl,-z,noexecstack -Wl,--hash-style=gnu -m64 -Wl,--package-metadata=%7B%22type%22:%22deb%22%2C%22os%22:%22ubuntu%22%2C%22name%22:%22openjdk-25-crac%22%2C%22version%22:%2225.0.3+9-0ubuntu1%22%2C%22architecture%22:%22amd64%22%7D -Xlinker -z -Xlinker relro -Xlinker -Bsymbolic-functions -Xlinker --no-as-needed -shared -O1 -m64 -Wl,--package-metadata=%7B%22type%22:%22deb%22%2C%22os%22:%22ubuntu%22%2C%22name%22:%22openjdk-25-crac%22%2C%22version%22:%2225.0.3+9-0ubuntu1%22%2C%22architecture%22:%22amd64%22%7D -Xlinker -z -Xlinker relro -Xlinker -Bsymbolic-functions -Xlinker --no-as-needed -Wl,-version-script=/build/openjdk-25-crac-CqlSYp/openjdk-25-crac-25.0.3+9/make/data/hotspot-symbols/version-script-gcc.txt -L/build/openjdk-25-crac-CqlSYp/openjdk-25-crac-25.0.3+9/build-zero/hotspot/variant-zero/libjvm/libgtest -Wl,-soname=libjvm.so -o /build/openjdk-25-crac-CqlSYp/openjdk-25-crac-25.0.3+9/build-zero/hotspot/variant-zero/libjvm/gtest/libjvm.so @/build/openjdk-25-crac-CqlSYp/openjdk-25-crac-25.0.3+9/build-zero/hotspot/variant-zero/libjvm/gtest/objs/_BUILD_GTEST_LIBJVM_objectfilenames.txt -lm -ldl -lpthread -lrt -lffi_pic -lgtest
/usr/bin/x86_64-linux-gnu-ld.bfd: /build/openjdk-25-crac-CqlSYp/openjdk-25-crac-25.0.3+9/build-zero/hotspot/variant-zero/libjvm/objs/cracRecompiler.o: in function `CRaCRecompiler::is_recompilation_relevant(methodHandle const&, int, int)':
make/hotspot/src/hotspot/share/runtime/cracRecompiler.cpp:204:(.text+0x74): undefined reference to `Method::code() const'
collect2: error: ld returned 1 exit status
```